### PR TITLE
TypeScript: Array of headers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 declare module 'js-file-downloader' {
   export interface OptionalParams {
     timeout?: number;
-    headers?: [{ name: string, value: string }];
+    headers?: { name: string, value: string }[];
     forceDesktopMode?: boolean;
     withCredentials?: boolean;
     method?: 'GET' | 'POST';


### PR DESCRIPTION
Hi.
There is a small typo in the current type definition of headers.
Written this way it allow only 1 header : 
`headers?: [{ name: string, value: string }];`

To allow multiple headers, the correct syntax is 
`headers?: { name: string, value: string }[]`

(or it could be `Array<{ name: string, value: string }>`)
